### PR TITLE
Fix compiler

### DIFF
--- a/deserialization/pom.xml
+++ b/deserialization/pom.xml
@@ -4,4 +4,8 @@
   <artifactId>deserialization</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <name>deserialization-demo</name>
+  <properties>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
 </project>


### PR DESCRIPTION
With Java 1.8 the source is not directly usable. With the specification of the compiler version it is compiling again.